### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/stg.yml
+++ b/.github/workflows/stg.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Build and push to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.event.repository.full_name }}
         username: MyceliumDeploy


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore